### PR TITLE
Fixing problem with returned content not being proper JSON format

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies.
  */
@@ -168,8 +167,12 @@ Resource.prototype.sync = function(fn) {
   var fn = fn || noop;
 
   this.query('one', function(err, body) {
-    if (!err) this.load(body);
-    fn(err, this.factory(body));
+    if (!err) {
+      this.load(body);
+      fn(err, this.factory(body));
+    } else {
+      fn(err,body);
+    }
   }.bind(this));
 };
 


### PR DESCRIPTION
If the body is not in proper JSON (e.g. the service returns an HTML file with an error in it instead of proper JSON - which was the case with the JIRA server) the script fails badly. This fix takes care of that.
